### PR TITLE
Add SetAuthMethod to Oauth2

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -146,6 +146,11 @@ func (c *Client) HttpClient() phttp.Client {
 	return c.hc
 }
 
+// set a specific auth method that can override the value set in NewClient
+func (c *Client) SetAuthMethod(authMethodValue string) {
+	c.authMethod = authMethodValue
+}
+
 // Generate the url for initial redirect to oauth provider.
 func (c *Client) AuthCodeURL(state, accessType, prompt string) string {
 	v := c.commonURLValues()

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -146,19 +146,17 @@ func (c *Client) HttpClient() phttp.Client {
 	return c.hc
 }
 
-//Allows for setting the authMethod that provides a workaround for the Ping OIDC issue
+// SetAuthMethodAllows allows for setting the authMethod that provides a workaround for the Ping OIDC issue
 // as noted in https://github.com/gravitational/teleport/issues/8374
 // The Ping OIDC will throw a multiple client credentials error due to the client id being
 // set in the query and basic auth with the client_secret_basic auth method.  client_secret_post
 // does not have that issue and this allows for setting that auth method. Since Ping
 // always returns client_secret_basic and client_secret_post as valid methods the default logic will always use client_secret_basic.
-
-// set a specific auth method that can override the value set in NewClient
 func (c *Client) SetAuthMethod(authMethodValue string) {
 	c.authMethod = authMethodValue
 }
 
-//returns the current assigned auth method.  Useful
+// GetAuthMethod returns the current assigned auth method.  Useful
 // for confirming what method has been used as part of the above Ping workaround
 func (c *Client) GetAuthMethod() string {
 	return c.authMethod

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -146,9 +146,22 @@ func (c *Client) HttpClient() phttp.Client {
 	return c.hc
 }
 
+//Allows for setting the authMethod that provides a workaround for the Ping OIDC issue
+// as noted in https://github.com/gravitational/teleport/issues/8374
+// The Ping OIDC will throw a multiple client credentials error due to the client id being
+// set in the query and basic auth with the client_secret_basic auth method.  client_secret_post
+// does not have that issue and this allows for setting that auth method. Since Ping
+// always returns client_secret_basic and client_secret_post as valid methods the default logic will always use client_secret_basic.
+
 // set a specific auth method that can override the value set in NewClient
 func (c *Client) SetAuthMethod(authMethodValue string) {
 	c.authMethod = authMethodValue
+}
+
+//returns the current assigned auth method.  Useful
+// for confirming what method has been used as part of the above Ping workaround
+func (c *Client) GetAuthMethod() string {
+	return c.authMethod
 }
 
 // Generate the url for initial redirect to oauth provider.

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -146,18 +146,18 @@ func (c *Client) HttpClient() phttp.Client {
 	return c.hc
 }
 
-// SetAuthMethodAllows allows for setting the authMethod that provides a workaround for the Ping OIDC issue
+// SetAuthMethodAllows allows for setting the authMethod variable that provides a workaround for the Ping OIDC issue
 // as noted in https://github.com/gravitational/teleport/issues/8374
 // The Ping OIDC will throw a multiple client credentials error due to the client id being
-// set in the query and basic auth with the client_secret_basic auth method.  client_secret_post
+// set in the query and basic auth with the Client Secret Basic auth method.  The Client Secret Post auth method
 // does not have that issue and this allows for setting that auth method. Since Ping
-// always returns client_secret_basic and client_secret_post as valid methods the default logic will always use client_secret_basic.
+// always returns  Client Secret Basic and Client Secret Post as available auth methods, the default logic will always use Client Secret Basic.
 func (c *Client) SetAuthMethod(authMethodValue string) {
 	c.authMethod = authMethodValue
 }
 
 // GetAuthMethod returns the current assigned auth method.  Useful
-// for confirming what method has been used as part of the above Ping workaround
+// for confirming what method has been used as part of the above Ping workaround.
 func (c *Client) GetAuthMethod() string {
 	return c.authMethod
 }


### PR DESCRIPTION
Adding a setauthmethod since we have a case with Ping where we need to only use the client_secret_post auth method.