### PR TITLE
oidc: allow none in TokenEndpointAuthMethodsSupported

### DIFF
--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gravitational/trace"
 	"io"
 	"io/ioutil"
 	"log"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/gravitational/trace"
 
 	"github.com/coreos/pkg/timeutil"
 	"github.com/jonboulle/clockwork"
@@ -355,9 +356,6 @@ func (p ProviderConfig) Valid() error {
 
 	if !contains(p.IDTokenSigningAlgValues, "RS256") {
 		return errors.New("id_token_signing_alg_values_supported must include 'RS256'")
-	}
-	if contains(p.TokenEndpointAuthMethodsSupported, "none") {
-		return errors.New("token_endpoint_auth_signing_alg_values_supported cannot include 'none'")
 	}
 
 	uris := []struct {


### PR DESCRIPTION
This pulls in the upstream fix from
https://github.com/coreos/go-oidc/commit/52cd73ca3b608a09147189ea64d8cae77a0d1422

This should fix OIDC with Okta, which includes "none" as a supported
auth method.